### PR TITLE
Fix: Ignore X/Twitter embed errors in production build

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -2,6 +2,9 @@ baseURL = 'https://example.org/'
 languageCode = 'en-us'
 title = 'My New Hugo Site'
 
+# Ignore X/Twitter embed errors in production build
+ignoreLogs = ['shortcode-x-getremote']
+
 [markup]
   [markup.goldmark]
     [markup.goldmark.renderer]


### PR DESCRIPTION
## Summary
X（Twitter）の埋め込みショートコードがGitHub Actionsのビルドで失敗する問題を修正

## Problem
GitHub Actionsでの本番ビルド時に、X.com APIへのアクセスがForbiddenエラーになり、ビルドが失敗していました。

```
ERROR template: _internal/shortcodes/x.html:20:25: executing "render-x" at <resources.GetRemote>: 
error calling GetRemote: failed to fetch remote resource from 'https://publish.x.com/oembed?...': Forbidden
```

## Solution
`hugo.toml`に`ignoreLogs = ['shortcode-x-getremote']`を追加して、このエラーを無視するように設定しました。

## Changes
- `hugo.toml`: `ignoreLogs`設定を追加

## Test plan
- [x] `hugo --minify`でローカルビルドが成功することを確認
- [ ] GitHub Actionsでビルドが成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)