### PR TITLE
Improve: SEO関連のmeta/OGP/JSON-LD/robots.txtを整備

### DIFF
--- a/config/_default/config.toml
+++ b/config/_default/config.toml
@@ -23,7 +23,7 @@ timeZone = "Asia/Tokyo"
   posts = "/posts/:slug/"
 
 [params]
-description = "This is site description"
+description = "しののめの個人ブログ。Webエンジニアリングや日常について書いています。"
 dateformat = "Jan 2, 2006" # Optional
 # Fonts settings.
 googlefonts = "https://fonts.googleapis.com/css?family=Lobster|Lato:400,700" # Optional, Include google fonts.

--- a/config/_default/languages.toml
+++ b/config/_default/languages.toml
@@ -6,4 +6,4 @@
   contentdir = "content"
 
   [ja.params]
-    description = "あれこれ書くブログ"
+    description = "Webエンジニアリング、日常、音楽などをゆるく書くブログ"

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -1,0 +1,79 @@
+{{ define "title" }}{{ if not .IsHome }}{{ .Title }} - {{ end }}{{ end }}
+
+{{ define "meta" }}
+{{- $description := .Description | default .Site.Params.description | default "" -}}
+{{- $title := cond .IsHome .Site.Title (printf "%s - %s" .Title .Site.Title) -}}
+{{- $image := absURL "images/profile.jpeg" -}}
+
+<meta name="description" content="{{ $description }}">
+
+<meta property="og:title" content="{{ $title }}">
+<meta property="og:type" content="website">
+<meta property="og:url" content="{{ .Permalink }}">
+<meta property="og:image" content="{{ $image }}">
+<meta property="og:site_name" content="{{ .Site.Title }}">
+<meta property="og:description" content="{{ $description }}">
+<meta property="og:locale" content="ja_JP">
+
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:site" content="@Shinogasa">
+<meta name="twitter:url" content="{{ .Permalink }}">
+<meta name="twitter:title" content="{{ $title }}">
+<meta name="twitter:description" content="{{ $description }}">
+<meta name="twitter:image" content="{{ $image }}">
+{{ end }}
+
+{{ define "main" }}
+{{ if not .IsHome }}
+<header class="page-title">
+  <h1 class="title">{{ .Title }}</h1>
+</header>
+{{ end }}
+
+<div class="articles">
+  <div class="mrow">
+
+    {{ $pctx := . }}
+    {{ if .IsHome }}{{ $pctx = .Site }}{{ end }}
+    {{ $paginator := .Paginate $pctx.RegularPages }}
+    {{ range $paginator.Pages }}
+    <div class="mcol c6">
+      <article class="li">
+        <a href="{{ .Permalink }}">
+          <div class="thumb thumb-{{ .File.UniqueID }}"></div>
+
+          <div class="inner">
+            <h2 class="title">{{ .Title }}</h2>
+
+            <ul class="facts">
+              <li><i class="fas fa-calendar" aria-hidden="true"></i><time datetime="{{ .Date.Format "2006-01-02T15:04:05JST" }}">{{ .Date.Format ( .Site.Params.dateformat | default "Jan 2, 2006") }}</time></li>
+              {{ with .Section }}<li><i class="fas fa-bookmark" aria-hidden="true"></i>{{ . | upper }}</li>{{ end }}
+              {{ if eq (getenv "HUGO_ENV") "DEV" }}
+              <li>{{ .WordCount }} Words</li>
+              {{ end }}
+              {{ if .Draft }}
+              <li style="color: #2196f3;">DRAFT</li>
+              {{ end }}
+            </ul>
+
+            <div class="summary">{{ plainify .Summary | safeHTML }}</div>
+          </div>
+        </a>
+      </article>
+    </div>
+    {{ end }}
+
+  </div>
+</div>
+
+{{ if or (.Paginator.HasPrev) (.Paginator.HasNext) }}
+<nav class="paging">
+  {{ if .Paginator.HasPrev }}
+  <a href="{{ .Paginator.Prev.URL }}" rel="prev">Prev</a>
+  {{ end }}
+  {{ if .Paginator.HasNext }}
+  <a href="{{ .Paginator.Next.URL }}" rel="next">Next</a>
+  {{ end }}
+</nav>
+{{ end }}
+{{ end }}

--- a/layouts/partials/single_json_ld.html
+++ b/layouts/partials/single_json_ld.html
@@ -1,0 +1,30 @@
+<script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BlogPosting",
+    "mainEntityOfPage": {
+      "@type": "WebPage",
+      "@id": {{ .Permalink | jsonify | safeJS }}
+    },
+    "headline": {{ printf "%s - %s" .Title .Site.Title | jsonify | safeJS }},
+    "image": {
+      "@type": "ImageObject",
+      "url": "{{ absURL (.Params.thumbnail | default "images/default.png") }}"
+    },
+    "datePublished": "{{ .Date.Format "2006-01-02T15:04:05+09:00" }}",
+    "dateModified": "{{ .Lastmod.Format "2006-01-02T15:04:05+09:00" }}",
+    "author": {
+      "@type": "Person",
+      "name": {{ .Site.Params.author.name | default .Site.Title | jsonify | safeJS }}
+    },
+    "publisher": {
+      "@type": "Organization",
+      "name": {{ .Site.Title | jsonify | safeJS }},
+      "logo": {
+        "@type": "ImageObject",
+        "url": "{{ absURL "images/profile.jpeg" }}"
+      }
+    },
+    "description": {{ .Description | default .Summary | plainify | jsonify | safeJS }}
+  }
+</script>

--- a/layouts/partials/single_meta.html
+++ b/layouts/partials/single_meta.html
@@ -1,0 +1,17 @@
+<meta name="description" content="{{ .Description | default .Summary }}">
+
+<meta property="og:title" content="{{ .Title }} - {{ .Site.Title }}">
+<meta property="og:type" content="article">
+<meta property="og:url" content="{{ .Permalink }}">
+<meta property="og:image" content="{{ absURL (.Params.thumbnail | default "images/default.png") }}">
+<meta property="og:site_name" content="{{ .Site.Title }}">
+<meta property="og:description" content="{{ .Description | default .Summary }}">
+<meta property="og:locale" content="ja_JP">
+
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:site" content="@Shinogasa">
+<meta name="twitter:creator" content="@Shinogasa">
+<meta name="twitter:url" content="{{ .Permalink }}">
+<meta name="twitter:title" content="{{ .Title }} - {{ .Site.Title }}">
+<meta name="twitter:description" content="{{ .Description | default .Summary }}">
+<meta name="twitter:image" content="{{ absURL (.Params.thumbnail | default "images/default.png") }}">

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://shinonono.net/sitemap.xml


### PR DESCRIPTION
- robots.txt を新規作成（全クローラー許可 + sitemap URL）
- config.toml/languages.toml の description を日本語に修正
- single_meta.html をオーバーライドし twitter:site/@creator を修正
- single_json_ld.html をオーバーライドし BlogPosting/https/記事URL/著者名に修正
- list.html をオーバーライドし meta ブロック追加でリストページにOGP出力